### PR TITLE
NTV-10 copying over tabs and channels configs to the backend, creating config objects and draft API

### DIFF
--- a/src/main/kotlin/com/ngenenius/api/config/StreamerProperties.kt
+++ b/src/main/kotlin/com/ngenenius/api/config/StreamerProperties.kt
@@ -1,0 +1,25 @@
+package com.ngenenius.api.config
+
+import com.ngenenius.api.model.platform.StreamingProvider
+import com.ngenenius.api.model.platform.StreamingTab
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "ngenius.streamer")
+data class StreamerProperties(val channels: List<ChannelProperties>)
+
+data class ChannelProperties(
+    /**
+     * The name of the channel / common identifier.
+     */
+    val id: String,
+    /**
+     * The platform this channel lives on.
+     */
+    val platform: StreamingProvider,
+    /**
+     * The tab(s) to show this channel on.
+     */
+    val tabs: List<StreamingTab>
+)

--- a/src/main/kotlin/com/ngenenius/api/config/StreamerProperties.kt
+++ b/src/main/kotlin/com/ngenenius/api/config/StreamerProperties.kt
@@ -5,9 +5,28 @@ import com.ngenenius.api.model.platform.StreamingTab
 import org.springframework.boot.context.properties.ConfigurationProperties
 import org.springframework.boot.context.properties.ConstructorBinding
 
+interface StreamerProvider {
+    fun channelNames(platform: StreamingProvider, tab: StreamingTab): Channels
+}
+
+interface TwitchStreamerProvider: StreamerProvider {
+
+    fun twitchStreamersFor(tab: StreamingTab): Channels {
+        return channelNames(StreamingProvider.TWITCH, tab)
+    }
+}
+
 @ConstructorBinding
 @ConfigurationProperties(prefix = "ngenius.streamer")
-data class StreamerProperties(val channels: List<ChannelProperties>)
+data class StreamerProperties(val channels: List<ChannelProperties>): StreamerProvider, TwitchStreamerProvider {
+
+    override fun channelNames(platform: StreamingProvider, tab: StreamingTab) =
+        Channels(
+            channels.filter{it.platform == platform}
+                .filter{it.tabs.contains(tab)}
+                .map{ it.id }
+        )
+}
 
 data class ChannelProperties(
     /**
@@ -23,3 +42,10 @@ data class ChannelProperties(
      */
     val tabs: List<StreamingTab>
 )
+
+data class Channels(val channels: List<String>) {
+    /**
+     * Helper function to convert a list of channels to the query params string the Twitch API expects.
+     */
+    fun channelsAsQueryParams() = channels.joinToString("&") { "user_login=$it" }
+}

--- a/src/main/kotlin/com/ngenenius/api/config/TwitchProperties.kt
+++ b/src/main/kotlin/com/ngenenius/api/config/TwitchProperties.kt
@@ -35,6 +35,7 @@ data class TwitchAuthProperties(
     val clientSecret: String
 )
 
+@Deprecated("Deprecated for now - may make a resurgence. Need to populate from Streamer properties.")
 data class TwitchStreamsProperties(
     /**
      * The channels list to query for in this twitch streams container.

--- a/src/main/kotlin/com/ngenenius/api/config/TwitchProperties.kt
+++ b/src/main/kotlin/com/ngenenius/api/config/TwitchProperties.kt
@@ -14,16 +14,11 @@ data class TwitchProperties(
      * The authentication properties container for twitch.
      */
     @NestedConfigurationProperty val auth: TwitchAuthProperties,
-    /**
-     * The configuration for the team-view twitch data
-     */
-    @NestedConfigurationProperty val teamView: TwitchStreamsProperties,
-    /**
-     * The configuration for the tournament view twitch data
-     */
-    @NestedConfigurationProperty val tournament: TwitchStreamsProperties
 )
 
+/**
+ * The configuration holder for our twitch client id and client secret.
+ */
 data class TwitchAuthProperties(
     /**
      * The client id for twitch authentication.
@@ -34,16 +29,3 @@ data class TwitchAuthProperties(
      */
     val clientSecret: String
 )
-
-@Deprecated("Deprecated for now - may make a resurgence. Need to populate from Streamer properties.")
-data class TwitchStreamsProperties(
-    /**
-     * The channels list to query for in this twitch streams container.
-     */
-    val channels: List<String>,
-) {
-    /**
-     * Helper function to convert a list of channels to the query params string the Twitch API expects.
-     */
-    fun channelsAsQueryParams() = channels.joinToString("&") { "user_login=$it" }
-}

--- a/src/main/kotlin/com/ngenenius/api/config/UiProperties.kt
+++ b/src/main/kotlin/com/ngenenius/api/config/UiProperties.kt
@@ -1,0 +1,23 @@
+package com.ngenenius.api.config
+
+import com.ngenenius.api.model.platform.StreamingTab
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "ngenius.ui")
+data class UiProperties(
+    /**
+     * A map of stream tab (on the team view) to it's properties.
+     *
+     * Useful since we have multiple tabs that show streaming content.
+     */
+    val tabs: Map<StreamingTab, TabProperties>
+)
+
+data class TabProperties(
+    /**
+     * Whether or not this tab is shown.
+     */
+    val display: Boolean
+)

--- a/src/main/kotlin/com/ngenenius/api/controller/ConfigController.kt
+++ b/src/main/kotlin/com/ngenenius/api/controller/ConfigController.kt
@@ -1,0 +1,23 @@
+package com.ngenenius.api.controller
+
+import com.ngenenius.api.config.StreamerProperties
+import com.ngenenius.api.config.UiProperties
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/config")
+class ConfigController(
+    private val uiProperties: UiProperties,
+    private val streamerProperties: StreamerProperties
+) {
+
+    val publicConfig = mapOf(
+        "tabs" to uiProperties.tabs,
+        "channels" to streamerProperties.channels
+    )
+
+    @GetMapping
+    fun publicConfiguration() = publicConfig
+}

--- a/src/main/kotlin/com/ngenenius/api/controller/ConfigController.kt
+++ b/src/main/kotlin/com/ngenenius/api/controller/ConfigController.kt
@@ -1,7 +1,10 @@
 package com.ngenenius.api.controller
 
+import com.ngenenius.api.config.ChannelProperties
 import com.ngenenius.api.config.StreamerProperties
+import com.ngenenius.api.config.TabProperties
 import com.ngenenius.api.config.UiProperties
+import com.ngenenius.api.model.platform.StreamingTab
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -9,15 +12,14 @@ import org.springframework.web.bind.annotation.RestController
 @RestController
 @RequestMapping("/v1/config")
 class ConfigController(
-    private val uiProperties: UiProperties,
-    private val streamerProperties: StreamerProperties
+    uiProperties: UiProperties,
+    streamerProperties: StreamerProperties
 ) {
 
-    val publicConfig = mapOf(
-        "tabs" to uiProperties.tabs,
-        "channels" to streamerProperties.channels
-    )
+    private val publicConfig = PublicConfig(uiProperties.tabs, streamerProperties.channels)
 
     @GetMapping
     fun publicConfiguration() = publicConfig
 }
+
+data class PublicConfig(val tabs: Map<StreamingTab, TabProperties>, val channels: List<ChannelProperties>)

--- a/src/main/kotlin/com/ngenenius/api/model/platform/StreamingProvider.kt
+++ b/src/main/kotlin/com/ngenenius/api/model/platform/StreamingProvider.kt
@@ -1,0 +1,10 @@
+package com.ngenenius.api.model.platform
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * The Stream Providers currently supported by this application.
+ */
+enum class StreamingProvider {
+    @JsonProperty("twitch") TWITCH
+}

--- a/src/main/kotlin/com/ngenenius/api/model/platform/StreamingTab.kt
+++ b/src/main/kotlin/com/ngenenius/api/model/platform/StreamingTab.kt
@@ -1,0 +1,11 @@
+package com.ngenenius.api.model.platform
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * The names of the tabs that are available in the application.
+ */
+enum class StreamingTab {
+    @JsonProperty("team-view") TEAM_VIEW,
+    @JsonProperty("tournament") TOURNAMENT
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -52,6 +52,110 @@ ngenius:
         - milehighfightnight
         - onibakuman
         - wellbornsteak
+  ui:
+    tabs:
+      team-view:
+        display: true
+      tournament:
+        display: true
+  streamer:
+    channels:
+      - id: NGeniusGaming
+        platform: twitch
+        tabs:
+          - team-view
+      - id: CD_Mangaka
+        platform: twitch
+        tabs:
+          - team-view
+      - id: Dashr40
+        platform: twitch
+        tabs:
+          - team-view
+      - id: ICrazyJI
+        platform: twitch
+        tabs:
+          - team-view
+      - id: SetTopVox
+        platform: twitch
+        tabs:
+          - team-view
+      - id: ngen_duo
+        platform: twitch
+        tabs:
+          - team-view
+      - id: ngen_zedd
+        platform: twitch
+        tabs:
+          - team-view
+      - id: KasumiSSJ
+        platform: twitch
+        tabs:
+          - team-view
+      - id: firstofmankind
+        platform: twitch
+        tabs:
+          - team-view
+      - id: yiinja
+        platform: twitch
+        tabs:
+          - team-view
+      - id: ngenwreck
+        platform: twitch
+        tabs:
+          - team-view
+      - id: tappanc
+        platform: twitch
+        tabs:
+          - team-view
+      - id: Natejesty
+        platform: twitch
+        tabs:
+          - team-view
+      - id: ngen_floridaman
+        platform: twitch
+        tabs:
+          - team-view
+      - id: RoyalHeartv2
+        platform: twitch
+        tabs:
+          - team-view
+      - id: Sol_xvii
+        platform: twitch
+        tabs:
+          - team-view
+      - id: QueenHollow
+        platform: twitch
+        tabs:
+          - team-view
+      - id: iCerby
+        platform: twitch
+        tabs:
+          - team-view
+      - id: Minimattt
+        platform: twitch
+        tabs:
+          - team-view
+      - id: adanimo
+        platform: twitch
+        tabs:
+          - team-view
+      - id: AkihabaraArcade
+        platform: twitch
+        tabs:
+          - tournament
+      - id: milehighfightnight
+        platform: twitch
+        tabs:
+          - tournament
+      - id: onibakuman
+        platform: twitch
+        tabs:
+          - tournament
+      - id: wellbornsteak
+        platform: twitch
+        tabs:
+          - tournament
 
 management:
   endpoints:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -24,34 +24,6 @@ ngenius:
     auth:
       client-id: ${TWITCH_CLIENT_ID}
       client-secret: ${TWITCH_CLIENT_SECRET}
-    team-view:
-      channels:
-        - NGeniusGaming
-        - CD_Mangaka
-        - Dashr40
-        - ICrazyJI
-        - SetTopVox
-        - ngen_duo
-        - ngen_zedd
-        - KasumiSSJ
-        - firstofmankind
-        - yiinja
-        - ngenwreck
-        - tappanc
-        - Natejesty
-        - ngen_floridaman
-        - RoyalHeartv2
-        - Sol_xvii
-        - QueenHollow
-        - iCerby
-        - Minimattt
-        - adanimo
-    tournament:
-      channels:
-        - AkihabaraArcade
-        - milehighfightnight
-        - onibakuman
-        - wellbornsteak
   ui:
     tabs:
       team-view:


### PR DESCRIPTION
First iteration of moving configuration into ngen-api (beyond more static configs)
Exposing `GET: /v1/config` to retrieve public config for the UI
Using this new configuration pattern to drive Twitch API usage