### PR TITLE
NTV-11 making sure the context can load in a Spring Boot test that on…

### DIFF
--- a/src/main/kotlin/com/ngenenius/api/config/StreamerProperties.kt
+++ b/src/main/kotlin/com/ngenenius/api/config/StreamerProperties.kt
@@ -1,5 +1,6 @@
 package com.ngenenius.api.config
 
+import com.fasterxml.jackson.annotation.JsonIgnore
 import com.ngenenius.api.model.platform.StreamingProvider
 import com.ngenenius.api.model.platform.StreamingTab
 import org.springframework.boot.context.properties.ConfigurationProperties
@@ -46,6 +47,7 @@ data class ChannelProperties(
      */
     val tabs: List<StreamingTab>
 ) {
+    @JsonIgnore
     val twitchIdentifier = TwitchIdentifier(id, displayName)
 }
 

--- a/src/test/kotlin/com/ngenenius/api/NgeniusApiApplicationTest.kt
+++ b/src/test/kotlin/com/ngenenius/api/NgeniusApiApplicationTest.kt
@@ -1,0 +1,20 @@
+package com.ngenenius.api
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestPropertySource
+
+@SpringBootTest
+@TestPropertySource(
+    properties = [
+        "TWITCH_CLIENT_ID=my-twitch-client-id",
+        "TWITCH_CLIENT_SECRET=my-twitch-client-secret"
+    ]
+)
+internal class NgeniusApiApplicationTest {
+
+    @Test
+    fun `Spring Boot Context should load`() {
+
+    }
+}


### PR DESCRIPTION
…ly provides env vars that we know are set in K8s