### PR TITLE
NTV-11 v1 of the new tab based details endpoint.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,6 +17,9 @@ val springCloudVersion: String by project
 val kotlinVersion: String by project
 val kotlinLogging: String by project
 val caffeineVersion: String by project
+val springdocVersion: String by project
+
+
 val mockitoKotlinVersion: String by project
 val assertJVersion: String by project
 
@@ -36,6 +39,7 @@ dependencies {
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 	implementation("io.github.microutils:kotlin-logging-jvm")
 	implementation("com.github.ben-manes.caffeine:caffeine")
+	implementation("org.springdoc:springdoc-openapi-ui:1.5.2")
 	runtimeOnly("org.springframework.boot:spring-boot-devtools")
 	kapt("org.springframework.boot:spring-boot-configuration-processor")
 	// literally only here to make IntelliJ happy - magic happens from the 'kapt' one. May not work with @ConstructorBinding?
@@ -60,6 +64,7 @@ dependencyManagement {
 			dependency("com.github.ben-manes.caffeine:caffeine:$caffeineVersion")
 			dependency("com.nhaarman.mockitokotlin2:mockito-kotlin:$mockitoKotlinVersion")
 			dependency("org.assertj:assertj-core:$assertJVersion")
+			dependency("org.springdoc:springdoc-openapi-ui:$springdocVersion")
 		}
 	}
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,7 @@ springCloudVersion=2020.0.0
 kotlinVersion=1.4.21
 kotlinLogging=2.0.4
 caffeineVersion=2.8.8
+springdocVersion=1.5.2
 
 mockitoKotlinVersion=2.2.0
 assertJVersion=3.18.1

--- a/src/main/kotlin/com/ngenenius/api/config/ApplicationCleanup.kt
+++ b/src/main/kotlin/com/ngenenius/api/config/ApplicationCleanup.kt
@@ -1,0 +1,76 @@
+package com.ngenenius.api.config
+
+import mu.KotlinLogging
+import org.springframework.beans.factory.DisposableBean
+import org.springframework.security.authentication.AnonymousAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.client.OAuth2AuthorizationContext
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.client.ExchangeFilterFunction
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+import reactor.core.publisher.Mono
+import java.time.Duration
+
+private val logger = KotlinLogging.logger { }
+
+@Component
+class ApplicationCleanup(
+    private val twitchAuthorizedClientProvider: OAuth2AuthorizedClientProvider,
+    private val clientRegistrationRepository: ClientRegistrationRepository,
+) : DisposableBean {
+
+    override fun destroy() {
+
+        logger.info { "In shutdown phase of the application. Attempting to revoke all OAuth2 Tokens." }
+
+        val twitchRegistration = clientRegistrationRepository.findByRegistrationId("twitch")
+        val context = OAuth2AuthorizationContext
+            .withClientRegistration(twitchRegistration)
+            .principal(
+                AnonymousAuthenticationToken(
+                    "ApplicationCleanup",
+                    "anonymousUser",
+                    mutableListOf(
+                        SimpleGrantedAuthority("ROLE_ANONYMOUS")
+                    )
+                )
+            )
+            .build()
+
+        val token = twitchAuthorizedClientProvider.authorize(context)
+
+        logger.info { "Attempting to revoke retrieved Twitch OAuth2 token: [${token?.accessToken?.tokenValue}]" }
+
+        WebClient.builder()
+            .filters { filters -> filters.addAll(VerboseWebClientLogger.filters) }
+            .baseUrl("https://id.twitch.tv")
+            .build()
+            .post()
+            .uri("/oauth2/revoke?client_id=${token?.clientRegistration?.clientId}&token=${token?.accessToken?.tokenValue}")
+            .retrieve()
+            .bodyToMono<String>()
+            .doOnEach { logger.info { "Raw Response Body: ${it.get()} <- successful calls have no body." } }
+            .block(Duration.ofMinutes(1L))
+
+        logger.info { "Completed custom application cleanup, resuming with normal scheduled duties." }
+    }
+
+    private object VerboseWebClientLogger {
+
+        private val requestLogger = ExchangeFilterFunction.ofRequestProcessor { request ->
+            logger.info { "Executing request: ${request.method()}: ${request.url()}" }
+            Mono.just(request)
+        }
+
+        private val responseLogger = ExchangeFilterFunction.ofResponseProcessor { response ->
+            logger.info { "Received response status: ${response.statusCode()}" }
+            Mono.just(response)
+        }
+
+        val filters = listOf(requestLogger, responseLogger)
+    }
+
+}

--- a/src/main/kotlin/com/ngenenius/api/config/ApplicationConfig.kt
+++ b/src/main/kotlin/com/ngenenius/api/config/ApplicationConfig.kt
@@ -2,14 +2,19 @@ package com.ngenenius.api.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import com.ngenenius.api.model.platform.StreamingTab
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.context.annotation.Primary
+import org.springframework.core.convert.converter.Converter
+import org.springframework.format.FormatterRegistry
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter
 import org.springframework.web.cors.CorsConfiguration
 import org.springframework.web.cors.CorsConfigurationSource
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 
 
 @Configuration
@@ -63,4 +68,20 @@ class ApplicationConfig(private val securityProperties: SecurityProperties) {
             }
         }
     }
+
+    @Bean
+    fun webMvcConfigurer(defaultObjectMapper: ObjectMapper): WebMvcConfigurer {
+        return object: WebMvcConfigurer {
+            override fun addFormatters(registry: FormatterRegistry) {
+                registry.addConverter(StringToStreamingTabConverter(defaultObjectMapper))
+            }
+        }
+    }
+}
+
+/**
+ * Delegate to Jackson to convert from a string to a [StreamingTab] when used as a Path parameter.
+ */
+class StringToStreamingTabConverter(private val objectMapper: ObjectMapper): Converter<String, StreamingTab> {
+    override fun convert(source: String): StreamingTab? = objectMapper.readValue("\"$source\"")
 }

--- a/src/main/kotlin/com/ngenenius/api/config/TwitchConfig.kt
+++ b/src/main/kotlin/com/ngenenius/api/config/TwitchConfig.kt
@@ -14,6 +14,7 @@ import org.springframework.http.MediaType
 import org.springframework.http.codec.json.Jackson2JsonDecoder
 import org.springframework.http.codec.json.Jackson2JsonEncoder
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProvider
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizedClientManager
@@ -33,20 +34,24 @@ class TwitchConfig {
     @Bean
     fun twitchAuthorizedClientManager(
         clientRegistrationRepository: ClientRegistrationRepository,
-        authorizedClientRepository: OAuth2AuthorizedClientRepository
+        authorizedClientRepository: OAuth2AuthorizedClientRepository,
+        twitchAuthorizedClientProvider: OAuth2AuthorizedClientProvider
     ): OAuth2AuthorizedClientManager {
-        // declare which pieces of the OAuth2 Spec this provider should enable
-        val authorizedClientProvider = OAuth2AuthorizedClientProviderBuilder.builder()
-            .clientCredentials()
-            .refreshToken()
-            .build()
         // create a client manager with this authorized client repository
         val twitchAuthorizedClientManager = DefaultOAuth2AuthorizedClientManager(
             clientRegistrationRepository, authorizedClientRepository
         )
-        twitchAuthorizedClientManager.setAuthorizedClientProvider(authorizedClientProvider)
+        twitchAuthorizedClientManager.setAuthorizedClientProvider(twitchAuthorizedClientProvider)
         return twitchAuthorizedClientManager
     }
+
+    // declare which pieces of the OAuth2 Spec this provider should enable
+    @Bean
+    fun twitchAuthorizedClientProvider(): OAuth2AuthorizedClientProvider =
+        OAuth2AuthorizedClientProviderBuilder.builder()
+            .clientCredentials()
+            .refreshToken()
+            .build()
 
     @Bean
     fun twitchObjectMapper(): ObjectMapper {

--- a/src/main/kotlin/com/ngenenius/api/controller/TwitchBetaController.kt
+++ b/src/main/kotlin/com/ngenenius/api/controller/TwitchBetaController.kt
@@ -6,6 +6,7 @@ import com.ngenenius.api.model.twitch.TwitchResponse
 import com.ngenenius.api.model.twitch.UserDetails
 import com.ngenenius.api.service.twitch.TwitchStreamsService
 import com.ngenenius.api.service.twitch.TwitchUsersService
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -14,7 +15,7 @@ import org.springframework.web.bind.annotation.RestController
 @RequestMapping("/twitch")
 class TwitchBetaController(
     private val twitchStreamsService: TwitchStreamsService,
-    private val twitchUsersService: TwitchUsersService
+    private val twitchUsersService: TwitchUsersService,
 ) {
 
     @GetMapping("/team-view")

--- a/src/main/kotlin/com/ngenenius/api/controller/TwitchBetaController.kt
+++ b/src/main/kotlin/com/ngenenius/api/controller/TwitchBetaController.kt
@@ -19,11 +19,11 @@ class TwitchBetaController(
 
     @GetMapping("/team-view")
     internal fun teamView(): TwitchResponse<StreamDetails> =
-        TwitchResponse(twitchStreamsService.teamViewDetails())
+        TwitchResponse(twitchStreamsService.streamDetails(StreamingTab.TEAM_VIEW))
 
     @GetMapping("/tournament")
     internal fun tournament(): TwitchResponse<StreamDetails> =
-        TwitchResponse(twitchStreamsService.tournamentDetails())
+        TwitchResponse(twitchStreamsService.streamDetails(StreamingTab.TOURNAMENT))
 
     @GetMapping("/users")
     internal fun users(): Collection<UserDetails> = twitchUsersService.users(StreamingTab.TEAM_VIEW)

--- a/src/main/kotlin/com/ngenenius/api/controller/TwitchController.kt
+++ b/src/main/kotlin/com/ngenenius/api/controller/TwitchController.kt
@@ -1,0 +1,16 @@
+package com.ngenenius.api.controller
+
+import com.ngenenius.api.model.platform.StreamingTab
+import com.ngenenius.api.service.twitch.TwitchDataService
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/v1/twitch")
+class TwitchController(private val twitchDataService: TwitchDataService) {
+
+    @GetMapping("/{tab}")
+    fun detailsByTab(@PathVariable tab: StreamingTab) = twitchDataService.twitchDetails(tab)
+}

--- a/src/main/kotlin/com/ngenenius/api/controller/TwitchUserLoginController.kt
+++ b/src/main/kotlin/com/ngenenius/api/controller/TwitchUserLoginController.kt
@@ -13,7 +13,6 @@ class TwitchUserLoginController(private val twitchUsersService: TwitchUsersServi
 
     @GetMapping("/login/{login}")
     fun lookupUserByLogin(@PathVariable login: String): Collection<UserDetails> {
-        println("Received $login")
         return twitchUsersService.findUsersByLogin(login)
     }
 }

--- a/src/main/kotlin/com/ngenenius/api/model/twitch/PublicTwitchObjects.kt
+++ b/src/main/kotlin/com/ngenenius/api/model/twitch/PublicTwitchObjects.kt
@@ -1,0 +1,9 @@
+/**
+ * Twitch API objects that are returned by the ngen api.
+ */
+package com.ngenenius.api.model.twitch
+
+data class AggregateTwitchResponse(
+    val user: UserDetails,
+    val stream: StreamDetails?
+)

--- a/src/main/kotlin/com/ngenenius/api/model/twitch/PublicTwitchObjects.kt
+++ b/src/main/kotlin/com/ngenenius/api/model/twitch/PublicTwitchObjects.kt
@@ -4,6 +4,17 @@
 package com.ngenenius.api.model.twitch
 
 data class AggregateTwitchResponse(
+    /**
+     * The Twitch user with basic details about their channel.
+     */
     val user: UserDetails,
+    /**
+     * Details about a current live stream.
+     */
     val stream: StreamDetails?
-)
+) {
+    /**
+     * Whether or not the user is live streaming.
+     */
+    val live = stream != null
+}

--- a/src/main/kotlin/com/ngenenius/api/service/twitch/TwitchDataService.kt
+++ b/src/main/kotlin/com/ngenenius/api/service/twitch/TwitchDataService.kt
@@ -2,6 +2,7 @@ package com.ngenenius.api.service.twitch
 
 import com.ngenenius.api.model.platform.StreamingTab
 import com.ngenenius.api.model.twitch.AggregateTwitchResponse
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 
 /**

--- a/src/main/kotlin/com/ngenenius/api/service/twitch/TwitchDataService.kt
+++ b/src/main/kotlin/com/ngenenius/api/service/twitch/TwitchDataService.kt
@@ -1,5 +1,9 @@
 package com.ngenenius.api.service.twitch
 
+import com.ngenenius.api.model.platform.StreamingTab
+import com.ngenenius.api.model.twitch.AggregateTwitchResponse
+import org.springframework.stereotype.Component
+
 /**
  * The [TwitchDataService] is responsible for orchestrating data from the individual
  * twitch services to provide an apex data object.  This data service _is not_ responsible
@@ -7,5 +11,22 @@ package com.ngenenius.api.service.twitch
  * to live, caching should be the responsibility of the individual data components, and not
  * the orchestration layer.
  */
-class TwitchDataService(private val twitchStreamsService: TwitchStreamsService) {
+@Component
+class TwitchDataService(
+    private val twitchStreamsService: TwitchStreamsService,
+    private val twitchUsersService: TwitchUsersService
+) {
+
+    /**
+     * Combines users details with optional stream details if that user is live at the
+     * time of calling this API.
+     */
+    fun twitchDetails(tab: StreamingTab): Collection<AggregateTwitchResponse> {
+        val users = twitchUsersService.users(tab)
+        val streams = twitchStreamsService.streamDetails(tab)
+            .map { it.userId to it }
+            .toMap()
+
+        return users.map{ AggregateTwitchResponse(it, streams[it.id]) }
+    }
 }

--- a/src/main/kotlin/com/ngenenius/api/service/twitch/TwitchStreamsService.kt
+++ b/src/main/kotlin/com/ngenenius/api/service/twitch/TwitchStreamsService.kt
@@ -30,13 +30,8 @@ class TwitchStreamsService(
         object : ParameterizedTypeReference<TwitchResponse<StreamDetails>>() {}
 
     /**
-     * Retrieve [TwitchResponse<StreamDetails>] for the team view page.
+     * Retrieve [StreamDetails] for the provided [StreamingTab]
      */
-    fun teamViewDetails(): Collection<StreamDetails> = findByTab(StreamingTab.TEAM_VIEW)
-
-    /**
-     * Retrieve [TwitchResponse<StreamDetails>] for the tournament view page.
-     */
-    fun tournamentDetails(): Collection<StreamDetails> = findByTab(StreamingTab.TOURNAMENT)
+    fun streamDetails(tab: StreamingTab): Collection<StreamDetails> = findByTab(tab)
 
 }

--- a/src/main/resources/application-localhost.yml
+++ b/src/main/resources/application-localhost.yml
@@ -1,0 +1,3 @@
+springdoc:
+  api-docs:
+    enabled: on

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -130,3 +130,7 @@ management:
     web:
       exposure:
         include: "*"
+
+springdoc:
+  api-docs:
+    enabled: off

--- a/src/test/kotlin/com/ngenenius/api/controller/TwitchBetaControllerTest.kt
+++ b/src/test/kotlin/com/ngenenius/api/controller/TwitchBetaControllerTest.kt
@@ -1,10 +1,8 @@
 package com.ngenenius.api.controller
 
+import com.ngenenius.api.model.platform.StreamingTab
 import com.ngenenius.api.service.twitch.TwitchStreamsService
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.times
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.*
 import org.junit.jupiter.api.Test
 
 internal class TwitchBetaControllerTest {
@@ -16,7 +14,7 @@ internal class TwitchBetaControllerTest {
     fun `Should use the twitch service for team view details when getting team view`() {
         controller.teamView()
 
-        verify(twitchService, times(1)).teamViewDetails()
+        verify(twitchService, times(1)).streamDetails(eq(StreamingTab.TEAM_VIEW))
 
         verifyNoMoreInteractions(twitchService)
     }
@@ -25,7 +23,7 @@ internal class TwitchBetaControllerTest {
     fun `Should use the twitch service for tournament details when getting tournament view`() {
         controller.tournament()
 
-        verify(twitchService, times(1)).tournamentDetails()
+        verify(twitchService, times(1)).streamDetails(eq(StreamingTab.TOURNAMENT))
 
         verifyNoMoreInteractions(twitchService)
     }


### PR DESCRIPTION
Add Springdoc (Swagger reference) when running locally to generate REST docs.
Add a shutdown bean to revoke Twitch OAuth tokens so we do not run out of tokens.
Add v1 of the new and improved Twitch api. Currently tab based only.

![image](https://user-images.githubusercontent.com/8010983/104947588-37fa5680-5979-11eb-8e19-2498a51921e2.png)
